### PR TITLE
fix: export 빌트인 함수 수정

### DIFF
--- a/include/ms_builtin.h
+++ b/include/ms_builtin.h
@@ -14,4 +14,6 @@ int	execute_pwd(void);
 int	execute_unset(t_token *token);
 int	execute_exit(t_token *token);
 
+int	is_declared(char *str);
+
 #endif

--- a/src/builtin/ft_env.c
+++ b/src/builtin/ft_env.c
@@ -12,6 +12,20 @@
 
 #include "../../include/minishell.h"
 
+int	is_declared(char *str)
+{
+	int	i;
+
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] == '=')
+			return (1);
+		i++;
+	}
+	return (0);
+}
+
 char *key_to_value_loc(char *key, char **envv)
 {
 	size_t	key_len;
@@ -35,6 +49,11 @@ int	ft_env(char **envv)
 	i = 0;
 	while (envv[i])
 	{
+		if (!is_declared(envv[i]))
+		{
+			i++;
+			continue ;
+		}
 		ft_putendl_fd(envv[i], 1);
 		i++;
 	}

--- a/src/builtin/ft_export.c
+++ b/src/builtin/ft_export.c
@@ -29,8 +29,6 @@ int is_valid_env(const char *str)
 			return 0;
 		i++;
 	}
-	if (str[i] != '=')
-		return 0;
 	return 1;
 }
 
@@ -41,7 +39,9 @@ int is_same_env_key(const char *str, const char *envv)
 		str++;
 		envv++;
 	}
-	return *str == '=' && *envv == '=';
+	if ((*envv == '\0' || *envv == '=') && (*str == '\0' || *str == '='))
+		return (1);
+	return (0);
 }
 
 int	ft_export(char *str, char ***envv)
@@ -55,6 +55,8 @@ int	ft_export(char *str, char ***envv)
 	while ((*envv)[++i])
 		if (is_same_env_key(str, (*envv)[i]))
 		{
+			if (!is_declared(str))
+				return (SUCCESS);
 			free((*envv)[i]);
 			(*envv)[i] = ft_strdup(str);
 			return (SUCCESS);
@@ -73,22 +75,34 @@ int	ft_export(char *str, char ***envv)
 	return (SUCCESS);
 }
 
-// todo : export while문 돌릴 때 중간에 에러 나도 뒤에 삽입 되어야 함.
+void	print_all_env(char **env)
+{
+	int	i;
+
+	i = 0;
+	while (env[i])
+	{
+		ft_putendl_fd(env[i], 1);
+		i++;
+	}
+}
+
 int	execute_export(t_token *token)
 {
 	int	i;
 	int	ret;
+	int	status;
 
-	ret = 0;
+	status = SUCCESS;
 	if (token->argc == 1)
-		ret = execute_env(token);
+		print_all_env(*(token->envp));
 	i = 1;
 	while (token->argv[i])
 	{
 		ret = ft_export(token->argv[i], token->envp);
 		if (ret != 0)
-			return (ret);
+			status = ret;
 		i++;
 	}
-	 return (ret);
+	return (status);
 }

--- a/src/parse/envp.c
+++ b/src/parse/envp.c
@@ -60,9 +60,11 @@ char	**split_envp(char *str)
 	delimiter = ft_strchr(str, '=');
 	if (delimiter == NULL)
 	{
-		s2[0] = NULL;
+		// 기존 코드 segmentaion fault 발생 문제로 인해 export a와 같이 "=" 없이 환경변수 등록 시 key는 파라미터로 들어온 str 전체, value는 NULL로 수정
+		s2[0] = safe_malloc((ft_strlen(str) + 1) * sizeof(char));
+		ft_strlcpy(s2[0], str, ft_strlen(str) + 1);
 		s2[1] = NULL;
-		return (NULL);
+		return (s2);
 	}
 	key_len = delimiter - str;
 	value_len = ft_strlen(delimiter + 1);


### PR DESCRIPTION
**[해결된 문제들]**
1. 여러 환경 변수 export 시 중간에 에러 발생하면 끊기는 문제 해결.
2. export 인자 없이 호출 시 선언되지 않은 환경 변수도 출력되어야 하는 문제 해결.

**[파싱부 수정 사항]**
envp.c 파일에서 split_envp() 함수에서 파라미터가 "a=1"과 같이 정상적으로 등호가 있는 경우가 아닌 등호가 없는 경우에 대해 split_envp() 실행 이후 접근 시 segmentaion fault 발생하는 문제 발견했습니다.
기존에 등호가 없으면 s2[0], s1[0]가 모두 NULL을 반환하던 것에서 등호가 없을 시 s2[0]에 인자로 들어온 문자열을 그대로 복사해 넣어주고, s2[1]만 NULL로 처리하여 반환하는 것으로 수정했습니다.