### PR TITLE
fix: signal 처리 보완 및 exit_code 보완

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ LIBFT = libft.a
 LIBFT_DIR = libft
 HEADER_DIR = include
 READLINE = -lreadline
+LINKING_FLAGS = -lreadline -L/opt/homebrew/opt/readline/lib
+COMFILE_FLAGS = -I/opt/homebrew/opt/readline/include
 
 NAME = minishell
 
@@ -36,6 +38,7 @@ EXECUTE = ./src/execute/execute.c \
 		./src/execute/redirect.c \
 		./src/execute/run_builtin.c \
 		./src/execute/run_cmd.c \
+		./src/execute/ms_wait.c \
 
 SIGNAL = ./src/signal/set_signal.c \
 		./src/signal/signal_handler.c \
@@ -55,6 +58,9 @@ SRCS =	./src/main.c \
 		$(SIGNAL) \
 		$(ERR) \
 
+%.o: %.c
+	$(CC) $(CFLAGS) $(COMFILE_FLAGS) -c $< -o $@
+
 OBJS = ${SRCS:.c=.o}
 
 all : $(NAME)
@@ -62,7 +68,7 @@ all : $(NAME)
 $(NAME) : $(OBJS)
 		make -C $(LIBFT_DIR)
 		cp $(LIBFT_DIR)/$(LIBFT) .
-		$(CC) $(CFLAGS) -I $(HEADER_DIR) $(OBJS) $(LIBFT) -o $(NAME) $(READLINE)
+		$(CC) $(CFLAGS) $(LINKING_FLAGS) -I $(HEADER_DIR) $(OBJS) $(LIBFT) -o $(NAME) $(READLINE)
 
 clean :
 		make clean -C $(LIBFT_DIR)

--- a/include/ms_signal.h
+++ b/include/ms_signal.h
@@ -8,6 +8,7 @@ void	set_terminal_print_on(void);
 
 void	sigint_heredoc_handler(int signum);
 void	sigint_prompt_handler(int signum);
+void	sigterm_prompt_handler();
 
 void	ft_signal_heredoc(void);
 void	ft_signal_prompt(void);

--- a/include/ms_wait.h
+++ b/include/ms_wait.h
@@ -1,0 +1,12 @@
+#ifndef MS_WAIT_H
+#define MS_WAIT_H
+
+# include "minishell.h"
+
+int	ms_w_int(int w);
+int	ms_wstatus(int x);
+int	ms_wifexited(int x);
+int	ms_wexitstatus(int x);
+int	status_to_exit_code(int status);
+
+#endif

--- a/src/builtin/ft_exit.c
+++ b/src/builtin/ft_exit.c
@@ -32,6 +32,5 @@ int	execute_exit(t_token *token)
 	}
 	else
 		status = perror_numeric("exit", token->argv[1]);
-	// todo : free에 대한 고민.
 	exit(status);
 }

--- a/src/builtin/ft_export.c
+++ b/src/builtin/ft_export.c
@@ -50,7 +50,7 @@ int	ft_export(char *str, char ***envv)
 	char	**new_envv;
 
 	if (!is_valid_env(str))
-		return (perror_identifier("export", str)); // todo : 생각 필요함.
+		return (perror_identifier("export", str));
 	i = -1;
 	while ((*envv)[++i])
 		if (is_same_env_key(str, (*envv)[i]))

--- a/src/error/error_detail.c
+++ b/src/error/error_detail.c
@@ -41,7 +41,7 @@ int	perror_not_set(char *cmd, char *arg)
 	ft_putstr_fd(arg, 2);
 	ft_putstr_fd(" ", 2);
 	ft_putendl_fd("not set", 2);
-	return (1);
+	return (ERROR);
 }
 
 int	perror_is_dir(char *arg)
@@ -61,12 +61,12 @@ int	perror_cmd_not_found(char *cmd)
 
 int	perror_no_permission(char *arg)
 {
-	return (perror_cmd_msg(arg, "Permission denied", 127));
+	return (perror_cmd_msg(arg, "Permission denied", 126));
 }
 
 int	perror_etc()
 {
 	ft_putstr_fd("ddsehll: ", 2);
 	ft_putendl_fd("unexpected error", 2);
-	return (1);
+	return (ERROR);
 }

--- a/src/execute/ms_wait.c
+++ b/src/execute/ms_wait.c
@@ -1,0 +1,30 @@
+int	ms_w_int(int w)
+{
+	return (*(int *)&(w));
+}
+
+int	ms_wstatus(int x)
+{
+	return (ms_w_int(x) & 0177);
+}
+
+int	ms_wifexited(int x)
+{
+	return (ms_wstatus(x) == 0);
+}
+
+int	ms_wexitstatus(int x)
+{
+	return (((x) & 0xff00) >> 8);
+}
+
+int	status_to_exit_code(int status)
+{
+	int	exit_code;
+
+	if (ms_wifexited(status))
+		exit_code = ms_wexitstatus(status);
+	else
+		exit_code = ms_wstatus(status) + 128;
+	return exit_code;
+}

--- a/src/execute/redirect.c
+++ b/src/execute/redirect.c
@@ -51,13 +51,13 @@ int	redirect_writefile(char *path, int need_reset)
 	else
 		fd = open(path, O_CREAT | O_RDWR | O_APPEND, 0644);
 	if (fd < 0)
-		return (check_file(path)); // todo : ERROR handling
+		return (check_file(path));
 	else if (fd == 0 || fd == 1)
 		return (SUCCESS);
 	if (dup2(fd, STDOUT_FILENO) < 0)
 	{
 		close(fd);
-		return (ERROR); // todo : ERROR handling
+		return (perror_cmd("dup2"));
 	}
 	close(fd);
 	return (SUCCESS);

--- a/src/execute/run_cmd.c
+++ b/src/execute/run_cmd.c
@@ -1,5 +1,6 @@
 #include "../../include/ms_execute.h"
 #include "../../include/ms_error.h"
+#include "../../include/ms_signal.h"
 
 /**
  * 환경 변수 PATH를 읽어 bin경로들에 대한 문자열 배열을 반환함.
@@ -91,12 +92,14 @@ void	start_cmd(t_token *token, char *heredoc)
 	int	ret;
 	int	exit_code;
 
-	if (handle_redirection(token, heredoc))
-		exit(1);
+	ft_signal_default();
+	exit_code = handle_redirection(token, heredoc);
+	if (exit_code != 0)
+		exit(exit_code);
 	ret = is_builtin(token);
 	if (ret != -1)
 		exit_code = do_builtin(token, ret);
 	else
-		exit_code = search_cmd(token);
+		search_cmd(token);
 	exit(exit_code);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -12,8 +12,16 @@
 
 #include "../include/minishell.h"
 #include "../include/ms_execute.h"
+#include "../include/ms_signal.h"
 
 int	g_exit_code = 0;
+
+void	sigterm_prompt_handler(void)
+{
+	ft_putstr_fd("\033[1A", STDERR_FILENO);
+	ft_putstr_fd("\033[12C", STDERR_FILENO);
+	ft_putstr_fd("exit\n", STDERR_FILENO);
+}
 
 char	*set_home(char **envp)
 {
@@ -33,6 +41,7 @@ void	init_env(t_env *env, char **envp)
 	env->envp_dict = NULL;
 }
 
+#include "../include/ms_wait.h"
 int	main(int argc, char **argv, char **envp)
 {
 	t_linkedlist	*token_list;
@@ -45,12 +54,16 @@ int	main(int argc, char **argv, char **envp)
 	(void) argv;
 	init_env(&env, envp);
 	envp_copy = ft_envpdup(envp);
+	ft_signal_prompt();
 	while (1)
 	{
 		token_list = NULL;
 		line = readline("minishell$ ");
 		if (!line)
+		{
+			sigterm_prompt_handler();
 			break ;
+		}
 		if (ft_strncmp(line, "", 1) == 0)
 		{
 			safe_free((void **) &line);

--- a/src/signal/set_signal.c
+++ b/src/signal/set_signal.c
@@ -28,6 +28,7 @@ void	ft_signal_prompt(void)
  */
 void	ft_signal_ignore(void)
 {
+	set_terminal_print_off();
 	signal(SIGINT, SIG_IGN);
 	signal(SIGQUIT, SIG_IGN);
 }
@@ -37,6 +38,7 @@ void	ft_signal_ignore(void)
  */
 void	ft_signal_default(void)
 {
+	set_terminal_print_on();
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
 }

--- a/src/signal/signal_handler.c
+++ b/src/signal/signal_handler.c
@@ -11,8 +11,8 @@ void	sigint_prompt_handler(int signum)
 {
 	(void)signum;
 	ft_putstr_fd("\n", STDERR_FILENO);
-	// 커서가 다음줄로 옮겨간것을 readline에 적용
-	// 현재 버퍼를 비워줌
-	// readline 메시지를 다시 출력
-	// $? 출력 시 1로 나오게 수정.
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+	// todo : 전역 변수를 1로 만들기.
 }


### PR DESCRIPTION
**[todo]**
- "execute/heredoc.c/read_heredoc()", "signal/signal_handler.c/sigint_prompt_handler()" : `status_to_exit_code(status)`의 반환 값을 전역 변수로 받기.