### PR TITLE
Hotfix: pid 관리 문제 해결.

### DIFF
--- a/src/execute/execute.c
+++ b/src/execute/execute.c
@@ -42,7 +42,7 @@ void	make_child(t_token *token, int fd[2], int fd_in, char *heredoc)
 {
 	static int	i;
 
-	if ((t_token *) token->list_info->head->content != token)
+	if ((t_token *) token->list_info->head->content == token)
 		i = 0;
 	token->list_info->pid[i] = fork();
 	if (token->list_info->pid[i] < 0)


### PR DESCRIPTION
list->pid[] 에 pid가 순서대로 담기지 않는 문제 발생. 조건문 수정.