### PR TITLE
fix : if no cmd but redirection exist

### DIFF
--- a/src/execute/run_builtin.c
+++ b/src/execute/run_builtin.c
@@ -19,6 +19,8 @@ int	is_builtin(t_token *token)
 {
 	int	len;
 
+	if (token->cmd == NULL)
+		return (-1);
 	len = ft_strlen(token->cmd) + 1;
 	if (ft_strncmp(token->cmd, "echo", len) == 0)
 		return (1);

--- a/src/execute/run_cmd.c
+++ b/src/execute/run_cmd.c
@@ -86,6 +86,8 @@ int	search_cmd(t_token *token)
 	struct stat	path_stat;
 
 	bin_path = find_executable_path(token->cmd, *(token->envp));
+	if (bin_path == NULL && token->file_head != NULL)
+		exit(SUCCESS);
 	if (bin_path == NULL)
 		exit(perror_cmd_not_found(token->cmd));
 	if (stat(bin_path, &path_stat) < 0)


### PR DESCRIPTION
```  bash
$ << a 
$ > a
$ << a | cmd 
```
와 같은 경우를 실행부에서 수정해봤는데 오류가 없는지 확인 부탁 드려요